### PR TITLE
fix HLTB HTTP call, it now requires a Referer header parameter

### DIFF
--- a/hltb.rb
+++ b/hltb.rb
@@ -39,6 +39,10 @@ params = { :page => "1", :queryString => query, :t => "games", :sorthead => "pop
 
 response =
   HTTParty.post("https://howlongtobeat.com/search_results?page=1",
+  :headers => {
+      "User-Agent" => "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:90.0) Gecko/20100101 Firefox/90.0",
+      "Referer" => "https://howlongtobeat.com/"
+  },    
   :body => params
   )
 


### PR DESCRIPTION
Hi there,

The HLTB API has "changed" - well, they've been getting more strict as to who can do the HTTP call. You need to add a Referer header now. I have tested this manually by fixing the `.rb` file locally, and then the workflow works again. 
Similar issues and fixes can be found at https://github.com/ckatzorke/howlongtobeat/commit/082db2167a4ecafd4266247182b85f35b12c51a7

Cheers,
Wouter